### PR TITLE
Remove allow failure for PHP7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ php:
   - 7.0
   - hhvm
 
-matrix:
-  allow _failures:
-    - php: 7.0
-
 before_script:
   - composer install --no-interaction --prefer-source
 


### PR DESCRIPTION
Remove allow failure for PHP version 7. Because new version comming soon and this library is stable for new PHP.
